### PR TITLE
Adding TargetNullValue to BindingExtension

### DIFF
--- a/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/BindingExtension.cs
+++ b/src/Markup/Avalonia.Markup.Xaml/MarkupExtensions/BindingExtension.cs
@@ -45,7 +45,8 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
                 Source = Source,
                 StringFormat = StringFormat,
                 RelativeSource = RelativeSource,
-                DefaultAnchor = new WeakReference(GetDefaultAnchor(descriptorContext))
+                DefaultAnchor = new WeakReference(GetDefaultAnchor(descriptorContext)),
+                TargetNullValue = TargetNullValue
             };
         }
 
@@ -83,5 +84,7 @@ namespace Avalonia.Markup.Xaml.MarkupExtensions
         public string StringFormat { get; set; }
 
         public RelativeSource RelativeSource { get; set; }
+        
+        public object TargetNullValue { get; set; }
     }
 }


### PR DESCRIPTION
I noticed that I cannot use TargetNullValue in XAML as it's not added to `BindingExtension` yet. I think this should fix this.

- What does the pull request do?
Adding `TargetNullValue ` so we can use it in XAML.

- What is the current behavior?
`TargetNullValue` is not part of `BindingExtension`.
